### PR TITLE
시나리오 2 - 낙관적 락 적용

### DIFF
--- a/scripts/issueCouponConstantRate.js
+++ b/scripts/issueCouponConstantRate.js
@@ -7,11 +7,11 @@ export const options = {
     scenarios: {
         issue_flow: {
             executor: 'constant-arrival-rate', // 초당 고정 RPS
-            rate: 10,                          // 1초당 50회
+            rate: 100,                          // 1초당 ,, 회
             timeUnit: '1s',
-            duration: '30s',                   // 총 30초간
-            preAllocatedVUs: 50,
-            maxVUs: 100,
+            duration: '120s',                   // 총 ,, 초간
+            preAllocatedVUs: 300,
+            maxVUs: 300,
         },
     },
     thresholds: {

--- a/scripts/issueCouponConstantRate.js
+++ b/scripts/issueCouponConstantRate.js
@@ -10,16 +10,15 @@ export const options = {
             rate: 100,                          // 1초당 ,, 회
             timeUnit: '1s',
             duration: '120s',                   // 총 ,, 초간
-            preAllocatedVUs: 300,
-            maxVUs: 300,
+            preAllocatedVUs: 500,
+            maxVUs: 500,
         },
     },
     thresholds: {
         // 비즈니스 요구사항
         'coupon_success_count':      ['count==30'],  // 재고 30개만 성공
-        'coupon_out_of_stock_count': ['count==70'],  // 나머지 70개는 재고부족
         'coupon_duplicate_count':    ['count==0'],   // 중복발급 없음
-        'coupon_lock_timeout_count': ['count==0'],   // 락 타임아웃 없음
+
         // HTTP SLA (원하면 추가)
         // http_req_failed: ['rate<0.01'],
         // http_req_duration: ['p(95)<500'],
@@ -31,9 +30,8 @@ const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
 // Counters
 export let successCount       = new Counter('coupon_success_count');
-export let outOfStockCount    = new Counter('coupon_out_of_stock_count');
 export let duplicateCount     = new Counter('coupon_duplicate_count');
-export let lockTimeoutCount   = new Counter('coupon_lock_timeout_count');
+export let networkErrorCount  = new Counter('network_error_count');
 
 export function setup() {
     const userIds = [];
@@ -84,24 +82,25 @@ export default function (data) {
         { headers: JSON_HEADERS }
     );
 
-    // JSON 파싱
+    // 1) 네트워크 에러 (DNS, 타임아웃 등)
+    if (res.error_code) {
+        networkErrorCount.add(1, { error: res.error_code });
+        return;
+    }
+
+    // 2) 비즈니스 에러 (4xx)
     let body = {};
     try { body = res.json(); } catch {}
 
-    // 상태별 Counter 증가
-    if (res.status === 200) {
-        successCount.add(1);
-
-    } else if (res.status === 400) {
-        if (body.message === '쿠폰 재고가 부족합니다.') {
-            outOfStockCount.add(1);
-        }
-        else if (body.message === '이미 발급받은 쿠폰입니다.') {
+    if (res.status === 400) {
+        if (body.message === '이미 발급받은 쿠폰입니다.') {
             duplicateCount.add(1);
         }
+        return;
+    }
 
-    } else if (res.status === 500
-        && body.message === '쿠폰 LOCK 획득 대기 시간이 초과되었습니다.') {
-        lockTimeoutCount.add(1);
+    // 3) 성공
+    if (res.status === 200) {
+        successCount.add(1);
     }
 }

--- a/src/main/java/rediclaim/couponbackend/controller/CouponController.java
+++ b/src/main/java/rediclaim/couponbackend/controller/CouponController.java
@@ -29,7 +29,7 @@ public class CouponController {
         }
 
         Long logId = logService.logRequest(request.getUserId(), couponId);
-        couponService.issueCoupon(request.getUserId(), couponId);
+        couponService.issueCoupon(request.getUserId(), couponId, logId);
         logService.logSuccess(logId);
 
         return BaseResponse.ok(null);

--- a/src/main/java/rediclaim/couponbackend/domain/Coupon.java
+++ b/src/main/java/rediclaim/couponbackend/domain/Coupon.java
@@ -25,6 +25,9 @@ public class Coupon extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     private User creator;
 
+    @Version
+    private Long version;
+
     @Builder
     private Coupon(String name, int remainingCount, User creator) {
         this.name = name;

--- a/src/main/java/rediclaim/couponbackend/domain/CouponIssueLog.java
+++ b/src/main/java/rediclaim/couponbackend/domain/CouponIssueLog.java
@@ -32,11 +32,25 @@ public class CouponIssueLog {
     @Column(nullable = false)
     private boolean issueStatus;
 
+    @Column(nullable = false)
+    private int attemptCount;
+
+    @Column(nullable = false)
+    private boolean isLastAttempt;
+
     public void changeIssueStatus(boolean issueStatus) {
         this.issueStatus = issueStatus;
     }
 
     public void setIssueTime(LocalDateTime issueTime) {
         this.issueTime = issueTime;
+    }
+
+    public void setAttemptCount(int attemptCount) {
+        this.attemptCount = attemptCount;
+    }
+
+    public void markLastAttempt() {
+        this.isLastAttempt = true;
     }
 }

--- a/src/main/java/rediclaim/couponbackend/repository/CouponRepository.java
+++ b/src/main/java/rediclaim/couponbackend/repository/CouponRepository.java
@@ -18,8 +18,8 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
     List<Coupon> findByRemainingCountGreaterThan(int count);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select c from Coupon c where c.id = :id")
-    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")})      // 3초 타임아웃
-    Optional<Coupon> findByIdForUpdate(@Param("id") Long id);
+//    @Lock(LockModeType.PESSIMISTIC_WRITE)
+//    @Query("select c from Coupon c where c.id = :id")
+//    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")})      // 3초 타임아웃
+//    Optional<Coupon> findByIdForUpdate(@Param("id") Long id);
 }

--- a/src/main/java/rediclaim/couponbackend/repository/UserCouponRepository.java
+++ b/src/main/java/rediclaim/couponbackend/repository/UserCouponRepository.java
@@ -2,6 +2,8 @@ package rediclaim.couponbackend.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import rediclaim.couponbackend.domain.Coupon;
+import rediclaim.couponbackend.domain.User;
 import rediclaim.couponbackend.domain.UserCoupon;
 
 import java.util.List;
@@ -10,4 +12,6 @@ import java.util.List;
 public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
 
     List<UserCoupon> findByUserId(Long userId);
+
+    boolean existsByUserAndCoupon(User user, Coupon coupon);
 }

--- a/src/main/java/rediclaim/couponbackend/service/CouponIssueLogService.java
+++ b/src/main/java/rediclaim/couponbackend/service/CouponIssueLogService.java
@@ -1,6 +1,8 @@
 package rediclaim.couponbackend.service;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,6 +15,7 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class CouponIssueLogService {
 
+    private static final Logger log = LogManager.getLogger(CouponIssueLogService.class);
     private final CouponIssueLogRepository logRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -22,6 +25,8 @@ public class CouponIssueLogService {
                 .couponId(couponId)
                 .requestTime(LocalDateTime.now())
                 .issueStatus(false)
+                .attemptCount(0)
+                .isLastAttempt(false)
                 .build();
         return logRepository.save(log).getId();
     }
@@ -31,6 +36,19 @@ public class CouponIssueLogService {
         logRepository.findById(id).ifPresent(log -> {
             log.setIssueTime(LocalDateTime.now());
             log.changeIssueStatus(true);
+        });
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateAttemptCount(Long id, int attemptCount) {
+        logRepository.findById(id).ifPresent(log -> log.setAttemptCount(attemptCount));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markLastAttempt(Long id, int attemptCount) {
+        logRepository.findById(id).ifPresent(log -> {
+            log.setAttemptCount(attemptCount);
+            log.markLastAttempt();
         });
     }
 }

--- a/src/test/java/rediclaim/couponbackend/service/CouponServiceInMultiThreadTest.java
+++ b/src/test/java/rediclaim/couponbackend/service/CouponServiceInMultiThreadTest.java
@@ -72,7 +72,7 @@ class CouponServiceInMultiThreadTest {
         for (User user : users) {
             executor.submit(() -> {
                 try {
-                    couponService.issueCoupon(user.getId(), coupon.getId());
+                    couponService.issueCoupon(user.getId(), coupon.getId(), 0L);
                     successCount.incrementAndGet();
                 } catch (Exception e) {
                     failCount.incrementAndGet();

--- a/src/test/java/rediclaim/couponbackend/service/CouponServiceTest.java
+++ b/src/test/java/rediclaim/couponbackend/service/CouponServiceTest.java
@@ -45,7 +45,7 @@ class CouponServiceTest {
         Coupon coupon = couponRepository.save(createCoupon("쿠폰1", 10, creator));
 
         //when
-        couponService.issueCoupon(user.getId(), coupon.getId());
+        couponService.issueCoupon(user.getId(), coupon.getId(), 0L);
 
         //then
         assertThat(coupon.getRemainingCount()).isEqualTo(9);
@@ -63,10 +63,10 @@ class CouponServiceTest {
         User user = userRepository.save(createUser("유저1"));
         Coupon coupon = couponRepository.save(createCoupon("쿠폰1", 10, creator));
 
-        couponService.issueCoupon(user.getId(), coupon.getId());        // 유저가 이미 쿠폰 발급한 상황
+        couponService.issueCoupon(user.getId(), coupon.getId(), 0L);        // 유저가 이미 쿠폰 발급한 상황
 
         //when //then
-        assertThatThrownBy(() -> couponService.issueCoupon(user.getId(), coupon.getId()))
+        assertThatThrownBy(() -> couponService.issueCoupon(user.getId(), coupon.getId(), 0L))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(USER_ALREADY_HAS_COUPON.getMessage());
     }
@@ -81,7 +81,7 @@ class CouponServiceTest {
         Coupon coupon = couponRepository.save(createCoupon("쿠폰1", 0, creator));
 
         //when //then
-        assertThatThrownBy(() -> couponService.issueCoupon(user.getId(), coupon.getId()))
+        assertThatThrownBy(() -> couponService.issueCoupon(user.getId(), coupon.getId(), 0L))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(COUPON_OUT_OF_STOCK.getMessage());
     }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,7 +6,7 @@ spring:
     password:
 
     hikari:
-      maximum-pool-size: 100    # 테스트용
+      maximum-pool-size: 50    # 테스트용
 
   jpa:
     hibernate:


### PR DESCRIPTION
## 요약
1. Coupon 엔티티에 Version 등록
- Coupon 조회시 Version 정보와 유저에게 해당 쿠폰을 발급 & Coupon의 재고를 차감한 이후 update 쿼리 날릴 시의 Version 정보가 다를 경우 현재 트랜잭션 롤백 & OptimisticLockingFailureException 발생하는 것을 확인
- 스프링의 @Retryable 어노테이션을 활용하여 OptimisticLockingFailureException 발생할 경우에 한하여 정해진 maxAttempts 값만큼 issueCoupon 메서드를 시도하도록 코드 수정

2. 비관적 락 -> 낙관적 락으로 코드 수정시 데드락 상황이 발생하는 이슈 해결
- 기존 비관적 락을 적용하였을때 issueCoupon 메서드의 로직은 아래와 같았음 
a) Coupon 엔티티를 Pessimistic_WRITE 락을 걸고 조회
b) Coupon 재고 차감
c) 유저가 해당 쿠폰을 발급받았다는 의미로 UserCoupon 엔티티 생성 후 save
d) UserCoupon 엔티티에 (userId, couponId) 쌍에 unique 제약 조건을 걸어서 유저가 특정 쿠폰을 중복 발급받는 것을 방지 (에러 발생시키므로 전체 트랜잭션 롤백)

- 이때 UserCoupon 엔티티에 Coupon 에 대해 foreign key 제약조건이 걸려있으므로 Coupon 에 낙관적 락을 걸 경우 데드락이 발생하는 것을 확인

- Coupon의 재고 정보를 update 하는 쿼리를 먼저 flush 하고, UserCoupon 을 save 하도록 코드를 수정함으로써 데드락 발생하는 이슈 해결

3. issueCoupon 메서드를 몇번 시도하는지를 기록하기 위해 로그용 엔티티인 IssueCouponLog 엔티티 및 관련 코드 수정

## 참고
https://velog.io/@woodyn1002/my-klas-%EB%82%99%EA%B4%80%EC%A0%81-%EB%9D%BD-vs-%EB%B9%84%EA%B4%80%EC%A0%81-%EB%9D%BD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 쿠폰 발급 시도 및 마지막 시도 여부를 기록하는 필드가 추가되어, 발급 로그에서 시도 횟수와 마지막 시도 여부를 확인할 수 있습니다.
    - 쿠폰 엔티티에 버전 관리가 도입되어 동시성 제어가 강화되었습니다.

- **버그 수정**
    - 네트워크 오류에 대한 카운터가 추가되어, 네트워크 문제 발생 시 더 정확한 오류 추적이 가능합니다.
    - 중복 쿠폰 발급 여부를 명확하게 확인하여 처리합니다.

- **성능 개선**
    - 쿠폰 발급 시 동시성 처리 방식이 변경되어, 더 많은 요청을 효율적으로 처리할 수 있습니다.
    - 테스트 환경의 커넥션 풀 크기가 조정되어 자원 사용이 최적화되었습니다.

- **테스트**
    - 테스트 코드가 최신 서비스 로직에 맞게 수정되었습니다.
    - 일부 멀티스레드 관련 테스트가 비활성화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->