### PR TITLE
시나리오 3 : kafka를 활용해 DB I/O 진행

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,16 +47,9 @@ dependencies {
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
 
-    // retry
-    implementation 'org.springframework.boot:spring-boot-starter-aop'
-    implementation 'org.springframework.retry:spring-retry'
-
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     testImplementation('com.github.codemonstur:embedded-redis:1.4.0')
-
-    // awaitility -> 비동기 코드의 타이밍 테스트
-    testImplementation 'org.awaitility:awaitility:4.2.2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     testImplementation('com.github.codemonstur:embedded-redis:1.4.0')
+
+    // awaitility -> 비동기 코드의 타이밍 테스트
+    testImplementation 'org.awaitility:awaitility:4.2.2'
 }
 
 tasks.named('test') {

--- a/scripts/issueCouponConstantRate.js
+++ b/scripts/issueCouponConstantRate.js
@@ -12,7 +12,7 @@ export const options = {
     scenarios: {
         issue_flow: {
             executor: 'constant-arrival-rate',      // 초당 고정 RPS
-            rate: 1000,                             // 1초당 ,, 회
+            rate: 10000,                             // 1초당 ,, 회
             timeUnit: '1s',
             duration: '120s',                       // 총 ,, 초간
             preAllocatedVUs: PREALLOCATED_VUS,
@@ -145,7 +145,7 @@ export default function (data) {
 
 export function teardown(data) {        // 부하테스트 이후 실행
     const { couponId } = data;
-    // Redis에 쌓인 쿠폰 발금 요청/완료 로그를 조회하는 검증 전용 api 호출
+    // Redis에 쌓인 쿠폰 발금 완료 로그를 조회하는 검증 전용 api 호출
     const res = http.get(`${BASE_URL}/api/coupons/${couponId}/verification-logs`);
     check(res, { 'got verification logs': r => r.status === 200 });
 
@@ -157,15 +157,18 @@ export function teardown(data) {        // 부하테스트 이후 실행
 
     const completions = result.completions || [];
 
-    // 성공 로그가 요청 순번에 대하여 오름차순 정렬(1, 2, ,,, N)인지 확인 -> 이래야 선착순 쿠폰 발급이 보장되는 것임
+    // 쿠폰 발급 완료 로그 중 요청 순번(requestSequence) 배열 추출
     const sequences = completions.map(r => r.requestSequence);
-    const N = QUANTITY;
-    const isSequential = sequences.length === N && sequences.every((v, i) => v === i + 1);
+
+    // 오름차순(우상향) 인지 확인 -> 이러면 선착순 쿠폰 발급 ok
+    const isAscending = sequences.every((v, i) => {
+        return i === 0 || v > sequences[i - 1];
+    });
 
     console.log(`Completion sequences : ${JSON.stringify(sequences)}`);
-    console.log(`Is true 선착순 쿠폰 발급? :  ${isSequential}`);
+    console.log(`쿠폰 발급 완료 로그의 요청 순번이 오름차순인가? :  ${isAscending}`);
 
-    check(isSequential, {
-        [`completion sequences are 1..${N}`]: v => v
+    check(isAscending, {
+        'completion sequences are monotonically increasing': v => v
     });
 }

--- a/scripts/issueCouponConstantRate.js
+++ b/scripts/issueCouponConstantRate.js
@@ -4,15 +4,16 @@ import { Counter } from 'k6/metrics';
 import { randomItem } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 const PREALLOCATED_VUS = 5000;      // 사전 예약된 VU 수
-const USER_COUNT= 50000;             // 생성할 유저 수
-const QUANTITY = 3000;               // 생성할 쿠폰의 수량
+const USER_COUNT= 100000;             // 생성할 유저 수
+const QUANTITY = 10000;               // 생성할 쿠폰의 수량
 
 export const options = {
     setupTimeout: '180s',       // setup 메서드가 실행되는 최대 대기 시간
+    teardownTimeout: '120s',    // teardown 메서드 timeout
     scenarios: {
         issue_flow: {
             executor: 'constant-arrival-rate',      // 초당 고정 RPS
-            rate: 10000,                             // 1초당 ,, 회
+            rate: 15000,                             // 1초당 ,, 회
             timeUnit: '1s',
             duration: '120s',                       // 총 ,, 초간
             preAllocatedVUs: PREALLOCATED_VUS,
@@ -21,7 +22,7 @@ export const options = {
     },
     thresholds: {
         // 비즈니스 요구사항
-        'coupon_success_count':      ['count==3000'],  // 쿠폰 수량만큼만 성공
+        'coupon_success_count':      ['count==10000'],  // 쿠폰 수량만큼만 성공
 
         // HTTP SLA (원하면 추가)
         // http_req_failed: ['rate<0.01'],
@@ -29,6 +30,7 @@ export const options = {
     },
 };
 
+// const BASE_URL = 'http://14.52.211.223:30002';
 const BASE_URL = 'http://localhost:8080';
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
@@ -43,7 +45,7 @@ export function setup() {
     const userIds = [];
 
     // 1) 일반 유저 생성 (배치 요청)
-    const batchSize = 2000;
+    const batchSize = 5000;
     let batchRequests = [];
     for (let i = 1; i <= USER_COUNT; i++) {
         batchRequests.push([

--- a/src/main/java/rediclaim/couponbackend/CouponBackendApplication.java
+++ b/src/main/java/rediclaim/couponbackend/CouponBackendApplication.java
@@ -2,12 +2,10 @@ package rediclaim.couponbackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableRetry
 @EnableAsync
 @EnableScheduling
 public class CouponBackendApplication {

--- a/src/main/java/rediclaim/couponbackend/CouponBackendApplication.java
+++ b/src/main/java/rediclaim/couponbackend/CouponBackendApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableRetry
 @EnableAsync
+@EnableScheduling
 public class CouponBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/rediclaim/couponbackend/domain/event/CouponIssueEvent.java
+++ b/src/main/java/rediclaim/couponbackend/domain/event/CouponIssueEvent.java
@@ -1,0 +1,17 @@
+package rediclaim.couponbackend.domain.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CouponIssueEvent {
+
+    private Long userId;
+
+    private Long couponId;
+}

--- a/src/main/java/rediclaim/couponbackend/global/config/KafkaConsumerConfig.java
+++ b/src/main/java/rediclaim/couponbackend/global/config/KafkaConsumerConfig.java
@@ -1,0 +1,34 @@
+package rediclaim.couponbackend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+import rediclaim.couponbackend.domain.event.CouponIssueEvent;
+import rediclaim.couponbackend.exception.CustomException;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, CouponIssueEvent> kafkaListenerContainerFactory(
+            ConsumerFactory<String, CouponIssueEvent> consumerFactory
+    ) {
+        ConcurrentKafkaListenerContainerFactory<String, CouponIssueEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+
+        // 1초 간격으로 최대 3회 재시도, 이후에는 스킵 (DLT로 메시지 이동)
+        FixedBackOff backOff = new FixedBackOff(1000L, 3L);
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(backOff);
+
+        // CustomException 에 대해서는 재시도 X
+        errorHandler.addNotRetryableExceptions(
+                CustomException.class
+        );
+
+        factory.setCommonErrorHandler(errorHandler);
+        return factory;
+    }
+}

--- a/src/main/java/rediclaim/couponbackend/global/config/KafkaConsumerConfig.java
+++ b/src/main/java/rediclaim/couponbackend/global/config/KafkaConsumerConfig.java
@@ -1,9 +1,12 @@
 package rediclaim.couponbackend.global.config;
 
+import org.apache.kafka.common.TopicPartition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.util.backoff.FixedBackOff;
 import rediclaim.couponbackend.domain.event.CouponIssueEvent;
@@ -14,16 +17,20 @@ public class KafkaConsumerConfig {
 
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, CouponIssueEvent> kafkaListenerContainerFactory(
-            ConsumerFactory<String, CouponIssueEvent> consumerFactory
-    ) {
+            ConsumerFactory<String, CouponIssueEvent> consumerFactory,
+            KafkaTemplate kafkaTemplate) {
         ConcurrentKafkaListenerContainerFactory<String, CouponIssueEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory);
 
-        // 1초 간격으로 최대 3회 재시도, 이후에는 스킵 (DLT로 메시지 이동)
-        FixedBackOff backOff = new FixedBackOff(1000L, 3L);
-        DefaultErrorHandler errorHandler = new DefaultErrorHandler(backOff);
+        // Dead-letter recoverer : send failing records to <topic>.DLT topic
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate, (record, ex) ->
+                new TopicPartition(record.topic() + ".DLT", record.partition()));
 
-        // CustomException 에 대해서는 재시도 X
+        // Retry up to 3 times, then publish to DLT
+        FixedBackOff backOff = new FixedBackOff(1000L, 3L);
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, backOff);
+
+        // CustomException 에 대해서는 재시도 X -> 즉시 DLT로
         errorHandler.addNotRetryableExceptions(
                 CustomException.class
         );

--- a/src/main/java/rediclaim/couponbackend/service/CouponIssueConsumer.java
+++ b/src/main/java/rediclaim/couponbackend/service/CouponIssueConsumer.java
@@ -1,0 +1,75 @@
+package rediclaim.couponbackend.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import rediclaim.couponbackend.domain.Coupon;
+import rediclaim.couponbackend.domain.User;
+import rediclaim.couponbackend.domain.UserCoupon;
+import rediclaim.couponbackend.domain.event.CouponIssueEvent;
+import rediclaim.couponbackend.exception.CustomException;
+import rediclaim.couponbackend.repository.CouponRepository;
+import rediclaim.couponbackend.repository.UserCouponRepository;
+import rediclaim.couponbackend.repository.UserRepository;
+
+import static rediclaim.couponbackend.exception.ExceptionResponseStatus.COUPON_NOT_FOUND;
+import static rediclaim.couponbackend.exception.ExceptionResponseStatus.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CouponIssueConsumer {
+
+    private static final String STOCK_KEY_PREFIX = "STOCK_";
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final UserCouponRepository userCouponRepository;
+    private final UserRepository userRepository;
+    private final CouponRepository couponRepository;
+
+    @KafkaListener(topics = "coupon-issue-events")
+    @Transactional
+    public void handleCouponIssue(CouponIssueEvent event) {
+        Long userId = event.getUserId();
+        Long couponId = event.getCouponId();
+        log.info("CouponIssueEvent 수신 : userId={}, couponId={}", userId, couponId);
+
+        Coupon coupon = couponRepository.findById(couponId)
+                .orElseThrow(() -> new CustomException(COUPON_NOT_FOUND));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        String stockKey = STOCK_KEY_PREFIX + couponId;
+
+        try {
+            // UserCoupon save
+            userCouponRepository.save(
+                    UserCoupon.builder()
+                            .user(user)
+                            .coupon(coupon)
+                            .build()
+            );
+
+            // Coupon 재고 update(redis의 쿠폰 재고 정보로 update)
+            String val = redisTemplate.opsForValue().get(stockKey);
+            if (val != null) {
+                int redisCount = Integer.parseInt(val);
+                coupon.setRemainingCount(redisCount);
+                couponRepository.save(coupon);
+            }
+
+            log.info("CouponIssueEvent 처리 완료 : userId={}, couponId={}", userId, couponId);
+        } catch (DataIntegrityViolationException e) {
+            log.warn("중복 CouponIssueEvent 수신 -> 무시합니다. : userId={}, couponId={}", userId, couponId);
+        } catch (Exception e) {
+            // UserCoupon 중복 save 를 제외한 다른 에러
+            // -> 재시도
+            log.error("CouponIsseuEvent 처리 중 예외 발생 : {}, message={}", e.getClass().getSimpleName(), e.getMessage());
+            throw e;
+        }
+    }
+}

--- a/src/main/java/rediclaim/couponbackend/service/CouponIssueConsumer.java
+++ b/src/main/java/rediclaim/couponbackend/service/CouponIssueConsumer.java
@@ -31,7 +31,7 @@ public class CouponIssueConsumer {
     private final UserRepository userRepository;
     private final CouponRepository couponRepository;
 
-    @KafkaListener(topics = "coupon-issue-events")
+    @KafkaListener(topics = "coupons")
     @Transactional
     public void handleCouponIssue(CouponIssueEvent event) {
         Long userId = event.getUserId();

--- a/src/main/java/rediclaim/couponbackend/service/CouponService.java
+++ b/src/main/java/rediclaim/couponbackend/service/CouponService.java
@@ -72,7 +72,7 @@ public class CouponService {
 
         Message<CouponIssueEvent> message = MessageBuilder
                 .withPayload(event)
-                .setHeader(KafkaHeaders.TOPIC, "coupon-issue-events")       // 토픽 설정
+                .setHeader(KafkaHeaders.TOPIC, "coupons")       // 토픽 설정
                 .setHeader(KafkaHeaders.KEY, couponId.toString())       // 메시지 Key(header)로 couponId 지정
                 .build();
 

--- a/src/main/java/rediclaim/couponbackend/service/CouponService.java
+++ b/src/main/java/rediclaim/couponbackend/service/CouponService.java
@@ -2,20 +2,22 @@ package rediclaim.couponbackend.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import rediclaim.couponbackend.controller.response.ValidCouponsResponse;
 import rediclaim.couponbackend.controller.response.ValidCoupon;
 import rediclaim.couponbackend.domain.*;
+import rediclaim.couponbackend.domain.event.CouponIssueEvent;
 import rediclaim.couponbackend.exception.CustomException;
 import rediclaim.couponbackend.repository.CouponRepository;
-import rediclaim.couponbackend.repository.UserCouponRepository;
 import rediclaim.couponbackend.repository.UserRepository;
 
-import java.util.Collections;
 import java.util.List;
 
 import static rediclaim.couponbackend.exception.ExceptionResponseStatus.*;
@@ -26,84 +28,74 @@ import static rediclaim.couponbackend.exception.ExceptionResponseStatus.*;
 public class CouponService {
 
     private static final String STOCK_KEY_PREFIX = "STOCK_";
+    private static final String ISSUED_USERS_KEY_PREFIX = "ISSUED_USERS_";
 
     private final RedisTemplate<String, String> redisTemplate;
-    private final UserCouponRepository userCouponRepository;
     private final CouponRepository couponRepository;
     private final UserRepository userRepository;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
 
-    // Lua script for atomic DECR
+    // Lua script for user duplicate check & atomic DECR
     private static final String ATOMIC_DECR_SCRIPT =
-            "local stock = redis.call('GET', KEYS[1])\n" +
-                    "if tonumber(stock) > 0 then\n" +
-                    "  return redis.call('DECR', KEYS[1])\n" +
+            "local userId = ARGV[1]\n" +
+                    "local stock = redis.call('GET', KEYS[1])\n" +
+                    "if redis.call('SISMEMBER', KEYS[2], userId) == 1 then\n" +
+                    "  return -2\n" +                // 이미 발급된 사용자
                     "end\n" +
-                    "return -1";
+                    "if tonumber(stock) <= 0 then\n" +
+                    "  return -1\n" +                // 재고 부족
+                    "end\n" +
+                    "redis.call('DECR', KEYS[1])\n" +
+                    "redis.call('SADD', KEYS[2], userId)\n" +  // 발급된 user set에 추가
+                    "return redis.call('GET', KEYS[1])";
 
     /**
-     * 유저가 발급한 적이 없는 쿠폰이고, 재고가 있을 경우 해당 유저에게 쿠폰을 발급해준다
-     * transactional 지우기
+     * 1. 사용자 쿠폰 발급 여부 검사 및 redis 쿠폰 재고 차감
+     * 2. DB I/O 을 위해 event publish
      */
     public void issueCoupon(Long userId, Long couponId) {
-        Coupon coupon = couponRepository.findById(couponId).orElseThrow(() -> new CustomException(COUPON_NOT_FOUND));
-        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
-
         String stockKey = STOCK_KEY_PREFIX + couponId;
-        Long remaining = allocateStockAtomically(stockKey);     // 쿠폰 재고 감소
-        if (remaining < 0) {        // 해당 쿠폰 재고 없음
+        String issuedUsersKey = ISSUED_USERS_KEY_PREFIX + couponId;
+
+        Long remaining = allocateStockAtomically(stockKey, issuedUsersKey, userId);
+        if (remaining == -2) {
+            throw new CustomException(USER_ALREADY_HAS_COUPON);
+        }
+        if (remaining == -1) {
             throw new CustomException(COUPON_OUT_OF_STOCK);
         }
 
-        try {
-            // UserCoupon save
-            userCouponRepository.save(UserCoupon.builder()
-                    .user(user)
-                    .coupon(coupon)
-                    .build());
+        CouponIssueEvent event = CouponIssueEvent.builder()
+                .userId(userId)
+                .couponId(couponId)
+                .build();
 
-            // Coupon update
-            syncCouponCountFromRedis(coupon, stockKey);
-        } catch (Exception e) {
-            redisTemplate.opsForValue().increment(stockKey);        // 쿠폰 재고 원복
-            syncCouponCountFromRedis(coupon, stockKey);
+        Message<CouponIssueEvent> message = MessageBuilder
+                .withPayload(event)
+                .setHeader(KafkaHeaders.TOPIC, "coupon-issue-events")       // 토픽 설정
+                .setHeader(KafkaHeaders.KEY, couponId.toString())       // 메시지 Key(header)로 couponId 지정
+                .build();
 
-            if (e instanceof DataIntegrityViolationException) {
-                throw new CustomException(USER_ALREADY_HAS_COUPON);
-            } else {
-                log.error(e.getMessage());
-                throw new CustomException(DATABASE_ERROR);
-            }
-        }
+        kafkaTemplate.send(message);
+        log.info("CouponIssueEvent 발행 (헤더 Key=couponId={}): userId={}, couponId={}", couponId, userId, couponId);
     }
 
     /**
-     * Redis에서 Lua 스크립트로 DECR/INCR을 원자화하여 재고를 할당
-     * @return 남은 재고(>=0) 또는 -1(재고 부족)
+     * @return
+     * -2 : 이미 해당 쿠폰을 발급한 유저
+     * -1 : 쿠폰 재고 부족
+     * 0 이상 : 쿠폰 발급 성공 -> 쿠폰 재고값 반환
      */
-    private Long allocateStockAtomically(String key) {
+    private Long allocateStockAtomically(String stockKey, String issuedUsersKey, Long userId) {
         DefaultRedisScript<Long> script = new DefaultRedisScript<>();
         script.setScriptText(ATOMIC_DECR_SCRIPT);
         script.setResultType(Long.class);
-        Long result = redisTemplate.execute(script, Collections.singletonList(key));
+
+        Long result = redisTemplate.execute(script, List.of(stockKey, issuedUsersKey), userId.toString());
         if (result == null) {
-            throw new RuntimeException("Failed to execute stock script for key: " + key);
+            throw new RuntimeException("Failed to execute stock script for key: " + stockKey);
         }
         return result;
-    }
-
-    private void syncCouponCountFromRedis(Coupon coupon, String key) {
-        // redis에 있는 쿠폰 재고 정보가 최신 정보이다 -> Coupon의 재고 정보는 redis의 값으로 update 해주면 된다
-        String val = redisTemplate.opsForValue().get(key);
-        if (val != null) {
-            try {
-                int redisCount = Integer.parseInt(val);
-                coupon.setRemainingCount(redisCount);
-                couponRepository.save(coupon);
-            } catch (NumberFormatException e) {
-                log.error("unable to parse redis stock value : {}", val);
-                throw e;
-            }
-        }
     }
 
     public ValidCouponsResponse showAllValidCoupons() {
@@ -131,6 +123,9 @@ public class CouponService {
 
         String stockKey = STOCK_KEY_PREFIX + saved.getId();
         redisTemplate.opsForValue().set(stockKey, String.valueOf(quantity));
+
+        String issuedUsersKey = ISSUED_USERS_KEY_PREFIX + saved.getId();
+        redisTemplate.delete(issuedUsersKey);       // 이전에 해당 쿠폰을 발급받은 유저들 정보는 전부 삭제
 
         return saved.getId();
     }

--- a/src/main/java/rediclaim/couponbackend/service/CouponStockSyncScheduler.java
+++ b/src/main/java/rediclaim/couponbackend/service/CouponStockSyncScheduler.java
@@ -1,0 +1,47 @@
+package rediclaim.couponbackend.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import rediclaim.couponbackend.domain.Coupon;
+import rediclaim.couponbackend.repository.CouponRepository;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CouponStockSyncScheduler {
+
+    private static final String STOCK_KEY_PREFIX = "STOCK_";
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final CouponRepository couponRepository;
+
+    @Scheduled(fixedRate = 5 * 60 * 1000)
+    public void syncCouponStock() {
+        List<Coupon> coupons = couponRepository.findAll();
+        for (Coupon coupon : coupons) {
+            String stockKey = STOCK_KEY_PREFIX + coupon.getId();
+            String value = redisTemplate.opsForValue().get(stockKey);
+
+            // redis에 키가 없으면 continue
+            if (value == null) continue;
+
+            try {
+                int redisCount = Integer.parseInt(value);
+                int dbCount = coupon.getRemainingCount();
+
+                if (redisCount != dbCount) {
+                    coupon.setRemainingCount(redisCount);
+                    couponRepository.save(coupon);
+                    log.info("쿠폰 재고 동기화 : couponId={}, dbCount={} -> redisCount={}", coupon.getId(), dbCount, redisCount);
+                }
+            } catch (NumberFormatException e) {
+                log.warn("redis 재고 값 파싱 실패 : stockKey={}, value={}", stockKey, value);
+            }
+        }
+    }
+}

--- a/src/test/java/rediclaim/couponbackend/config/EmbeddedRedisConfig.java
+++ b/src/test/java/rediclaim/couponbackend/config/EmbeddedRedisConfig.java
@@ -2,32 +2,52 @@ package rediclaim.couponbackend.config;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import redis.embedded.RedisServer;
 
 import java.io.IOException;
+import java.net.ServerSocket;
 
 @Configuration
 @Profile("test")
 public class EmbeddedRedisConfig {
 
-    @Value("${spring.data.redis.port}")
     private int redisPort;
 
     private RedisServer redisServer;
 
     @PostConstruct
     public void startRedis() throws IOException {
-        redisServer = new RedisServer(redisPort);
-        redisServer.start();
+        // 1) 사용 가능한 포트 번호를 찾아서 port 변수에 할당
+        redisPort = findAvailablePort();
+
+        // 2) 찾아낸 포트로 RedisServer 빌드
+        this.redisServer = new RedisServer(redisPort);
+
+        // 3) Redis 프로세스 시작
+        this.redisServer.start();
+
+        // 4) Spring이 읽도록 system property 또는 환경 변수로 포트 값을 주입
+        //    test 환경에서는 application-test.yml 대신 이 값이 적용됨
+        System.setProperty("spring.data.redis.port", String.valueOf(redisPort));
     }
 
     @PreDestroy
     public void stopRedis() throws IOException {
         if (redisServer != null) {
             redisServer.stop();
+        }
+    }
+
+    /**
+     * @return JVM이 실행 중인 환경에서 사용 가능한 포트 하나를 찾아서 반환한다.
+     * 여러 테스트가 병렬적으로 수행될 경우 address in use error를 막기 위함
+     */
+    private int findAvailablePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
         }
     }
 }

--- a/src/test/java/rediclaim/couponbackend/service/CouponServiceInMultiThreadTest.java
+++ b/src/test/java/rediclaim/couponbackend/service/CouponServiceInMultiThreadTest.java
@@ -19,6 +19,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.time.Duration.ofSeconds;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 import static rediclaim.couponbackend.domain.UserType.*;
 
@@ -99,18 +102,21 @@ class CouponServiceInMultiThreadTest {
         Thread.sleep(1000);
 
         //then
-        // 최종 쿠폰 재고 상태 확인
-        Coupon updatedCoupon = couponRepository.findById(coupon.getId()).orElseThrow();
+        // 최종 쿠폰 재고 상태 확인 -> 최대 5초 동안 100ms 마다 재고가 0이 될 때까지 폴링
+        await().atMost(ofSeconds(5))
+                .pollInterval(ofSeconds(0, 100))
+                .untilAsserted(() -> {
+                    Coupon updatedCoupon = couponRepository.findById(coupon.getId()).orElseThrow();
 
-        System.out.println("성공한 요청 건수: " + successCount.get());
-        System.out.println("실패한 요청 건수: " + failCount.get());
-        System.out.println("남은 쿠폰 재고: " + updatedCoupon.getRemainingCount());
-
-        assertAll("쿠폰 발급 통계",
-                () -> assertEquals(10, successCount.get(), "성공 요청 수는 100이어야 합니다."),
-                () -> assertEquals(90, failCount.get(), "실패 요청수는 900이어야 합니다."),
-                () -> assertEquals(0, updatedCoupon.getRemainingCount(), "남은 쿠폰 재고는 0이어야 합니다.")
-        );
+                    System.out.println("성공한 요청 건수: " + successCount.get());
+                    System.out.println("실패한 요청 건수: " + failCount.get());
+                    System.out.println("남은 쿠폰 재고: " + updatedCoupon.getRemainingCount());
+                    assertAll("쿠폰 발급 통계",
+                            () -> assertEquals(10, successCount.get(), "성공 요청 수는 100이어야 합니다."),
+                            () -> assertEquals(90, failCount.get(), "실패 요청수는 900이어야 합니다."),
+                            () -> assertEquals(0, updatedCoupon.getRemainingCount(), "남은 쿠폰 재고는 0이어야 합니다.")
+                    );
+                });
     }
 
     private User createUser(String name) {

--- a/src/test/java/rediclaim/couponbackend/service/CouponServiceTest.java
+++ b/src/test/java/rediclaim/couponbackend/service/CouponServiceTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 import rediclaim.couponbackend.controller.response.ValidCouponsResponse;
 import rediclaim.couponbackend.domain.*;
@@ -21,7 +23,11 @@ import static rediclaim.couponbackend.exception.ExceptionResponseStatus.*;
 
 @SpringBootTest
 @ActiveProfiles("test")
-@Transactional(readOnly = true)
+@EmbeddedKafka
+@TestPropertySource(properties = {
+        // spring.embedded.kafka.brokers 에서 자동으로 생성된 브로커 주소를 사용하도록 오버라이드
+        "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}"
+})
 class CouponServiceTest {
 
     @Autowired
@@ -43,7 +49,6 @@ class CouponServiceTest {
 
     @Test
     @DisplayName("유저는 이전에 발급한 적이 없고, 재고가 있는 쿠폰을 발급받을 수 있다.")
-    @Transactional
     void issue_coupon_success() throws Exception {
         //given
         User creator = userRepository.save(createCreator("쿠폰생성자1"));
@@ -57,15 +62,16 @@ class CouponServiceTest {
         couponService.issueCoupon(user.getId(), coupon.getId());
 
         //then
-        assertThat(coupon.getRemainingCount()).isEqualTo(9);
+        Thread.sleep(1000);     // 비동기적으로 DB i/o 가 발생하므로 잠깐 wait
+        Coupon updatedCoupon = couponRepository.findById(coupon.getId()).orElseThrow();
+        assertThat(updatedCoupon.getRemainingCount()).isEqualTo(9);
 
-        UserCoupons userCoupons = UserCoupons.of(userCouponRepository.findByUserId(user.getId()));
-        assertThat(userCoupons.hasCoupon(coupon.getId())).isTrue();
+//        UserCoupons userCoupons = UserCoupons.of(userCouponRepository.findByUserId(user.getId()));
+//        assertThat(userCoupons.hasCoupon(coupon.getId())).isTrue();
     }
 
     @Test
     @DisplayName("유저는 이미 발급받은 쿠폰을 재발급 받을 수 없다.")
-    @Transactional
     void can_not_issue_coupon_for_already_issued() throws Exception {
         //given
         User creator = userRepository.save(createCreator("쿠폰생성자1"));
@@ -85,7 +91,6 @@ class CouponServiceTest {
 
     @Test
     @DisplayName("유저는 재고가 없는 쿠폰을 발급받을 수 없다.")
-    @Transactional
     void can_not_issue_out_of_stock_coupon() throws Exception {
         //given
         User creator = userRepository.save(createCreator("쿠폰생성자1"));

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -22,14 +22,14 @@ spring:
   data:
     redis:
       host: localhost
-      port: 6380    # 6379 port는 사용중
 
   kafka:
     bootstrap-servers: localhost:9092
     producer:
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
     consumer:
-      group-id: coupon-backend-group
+      group-id: coupon-backend-group-test
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
         spring.json.trusted.packages: "rediclaim.couponbackend.*"
+      auto-offset-reset: latest


### PR DESCRIPTION
## 요약
쿠폰 발급 요청이 대규모 트래픽으로 들어오는 상황을 가정할 때, 유저에게

1. 쿠폰 발급 성공 (200 OK)
2. 이미 발급받은 쿠폰이므로 쿠폰을 발급받을 수 없음 (400 error)
3. 쿠폰 재고가 없으므로 쿠폰을 발급받을 수 없음 (400 error)

3가지 중 하나를 빠르게 return 하기 위해서 쿠폰 발급 로직과 DB I/O와 관련된 코드를 분리

### 쿠폰 발급 로직을 담당하는 CouponService.issueCoupon 메서드 
- redis lua script를 활용해 현재 위의 1,2,3 중 어떤 상황인지 원자적으로 판단   
  - 2 or 3 에 해당하는 경우 CustomException을 throw 
  - 1에 해당하는 경우 redis에서의 쿠폰 재고 값을 DECR & DB에 UserCoupon save 와 Coupon의 재고정보 update를 위해 event 발행
  
### DB I/O 작업을 담당하는 CouponIssueConsumer.handleCouponIssue 메서드(= kafka listener)
- event를 수신하여 DB에 UserCoupon save & redis의 쿠폰 재고 값으로 Coupon 의 재고 정보를 update 시도
- KafkaConsumerConfig 에 kafka listener의 재시도 로직을 정의
  - userId, couponId 로 엔티티 조회 시 CustomException 이 발생할 경우, 재시도 X
  - UserCoupon save 중 user_coupon 에 설정된 (user, coupon) unique 제약조건에 의해 DataIntegrityViolationException 이 발생할 경우, warning log만 출력하고 현재 메시지 commit
    - 이미 동일한 (user, coupon) 쌍에 대한 UserCoupon 데이터가 DB에 저장된 상태이므로 추가적인 DB 쓰기 작업 없이 다음 메시지로 넘어가도 되므로
  - 그 외 모든 DB 쓰기 연산시에 발생하는 exception에 대해서는 최대 3회 재시도 (이후에는 DLT로 메시지 이동)
  - 전체 DB 쓰기 연산이 재시도되도록 handleCouponIssue 메서드에 @Transactional 설정

### 테스트 스크립트 수정
선착순 쿠폰 발급의 모니터링을 위해 쿠폰 발급 성공에 해당하는 로그 정보들을 조회한 후, 해당 로그의 '쿠폰 발급 요청 순번' 값이 오름차순 인지 검증하도록 코드 수정

### 부하테스트 결과
유저 50000명, 쿠폰 수량 3000개, 초당 10000회로 부하 테스트 진행 시, 정해진 쿠폰 수량만큼 쿠폰 발급이 성공하고 DB 에도 데이터들이 잘 들어가있는것을 확인했습니다
<img width="788" alt="image" src="https://github.com/user-attachments/assets/8fca64e8-a442-45d8-a049-b8cac79c752f" />
-> 빨간색 실패는 쿠폰 발급 성공 로그의 요청 순번 값들이 오름차순이 아니어서 발생한 것입니닷 (추후에 로그를 찍는 시점에 대해서도 고민해보아야 할 것 같습니다!)

<img width="1285" alt="image" src="https://github.com/user-attachments/assets/d5ef523c-14ff-4318-b590-7ade0491fd79" />

<img width="874" alt="image" src="https://github.com/user-attachments/assets/de8c6a61-91f8-477e-a204-d0a15f4fa03e" />

## 리뷰 요구사항
일단 쿠폰 발급을 담당하는 로직에서는 DB와 커넥션 없이 redis의 lua script 연산만을 통해 '유저의 쿠폰 발급 여부, 쿠폰 재고값' 을 알 수 있도록 하였고, DB 커넥션이 필요한 코드들은 모두 kafka event를 수신받아 비동기적으로 처리하도록 구현하였습니다!

하지만 이 방식은 DB가 아니라, redis에서의 유저-쿠폰 발급 여부, 쿠폰의 재고값을 바탕으로 유저에게 미리 응답하는 방식이라 저번에 진영님께서 언급해주셨던것처럼 실제 DB i/o 시에 문제가 발생하면 후처리를 어떻게 해야할지 애매해지는 것 같습니다.

DB 커넥션이 필요한 작업까지 모두 동기적으로 수행할 수 있으면서도, 쿠폰 발급 요청이 대규모 트래픽으로 들어오는 경우를 커버할 수 있는 방식에 대해서 좀 더 고민해보겠습니다! 혹시 생각하시는 다른 구현방식이 있으면 공유해주시면 감사하겠습니다!
(저번에 카프카 컨슈머를 여러개 띄워서 병렬적으로 처리하면 괜찮지 않나? 라고 말씀하신거 같긴한데 제가 제대로 못알아들은거 같습니다ㅎ)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 쿠폰 발급 이벤트를 처리하는 Kafka 기반 비동기 아키텍처 도입
    - 쿠폰 재고 동기화를 위한 스케줄러 추가(5분마다 Redis와 DB 간 동기화)
    - 쿠폰 발급 이벤트 및 소비자, Kafka 설정 등 주요 이벤트 기반 클래스 추가

- **버그 수정**
    - 테스트 환경에서 Redis 포트 충돌 방지를 위한 동적 포트 할당 적용

- **테스트**
    - Kafka 및 Redis 환경을 반영한 통합 테스트 및 동시성 테스트 개선
    - 쿠폰 재고 동기화 검증 로직 명확화

- **환경설정/빌드**
    - 불필요한 Retry 관련 라이브러리 및 어노테이션 제거
    - 테스트용 Kafka, Redis 설정 및 consumer group 분리

- **기타**
    - 대규모 부하 테스트 파라미터 조정 및 검증 로직 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->